### PR TITLE
feat: exit on "unhandledRejection"

### DIFF
--- a/scripts/monitorBalances.ts
+++ b/scripts/monitorBalances.ts
@@ -101,3 +101,8 @@ if (require.main === module) {
   loadEnv()
   main().catch(error => console.error(error))
 }
+
+process.on('unhandledRejection', function(e) {
+  console.error('An error occured', e.message)
+  process.exit(1)
+})


### PR DESCRIPTION
Exit the process on an "unhandledRejection" so the process can be restarted by the process monitor. 

Without this, when the ssh tunnel si down or the eth node dies the monitor stops working with an unhandled promise rejection: `Invalid JSON RPCresponse: ""`.

This kills the process so supervisor con restart it