### PR TITLE
fix: mobile headers

### DIFF
--- a/webapp/src/components/PollDetailPage/PollDetailPage.css
+++ b/webapp/src/components/PollDetailPage/PollDetailPage.css
@@ -46,6 +46,11 @@
   margin-top: 40px;
 }
 
+.PollDetailPage .mobile-header {
+  display: none;
+  font-weight: bold;
+}
+
 @media (max-width: 768px) {
   .PollDetailPage .votes {
     margin-top: 0px;
@@ -59,5 +64,14 @@
     margin-left: 8px;
     min-width: 15px;
     padding: 12px;
+  }
+
+  .PollDetailPage .mobile-header {
+    display: inline;
+  }
+
+  .ui.table:not(.unstackable) td:first-child,
+  .ui.table:not(.unstackable) th:first-child {
+    font-weight: normal;
   }
 }

--- a/webapp/src/components/PollDetailPage/PollDetailPage.tsx
+++ b/webapp/src/components/PollDetailPage/PollDetailPage.tsx
@@ -236,15 +236,29 @@ export default class PollDetailPage extends React.PureComponent<Props, State> {
                       .map((vote, index) => (
                         <Table.Row key={vote.id + index}>
                           <Table.Cell title={formatDateTime(vote.timestamp)}>
+                            <span className="mobile-header">
+                              {t('poll_detail_page.when')}
+                              :&nbsp;
+                            </span>
                             {formatDate(vote.timestamp)}
                           </Table.Cell>
                           <Table.Cell>
+                            <span className="mobile-header">
+                              {t('poll_detail_page.address')}
+                              :&nbsp;
+                            </span>
                             <Blockie scale={3} seed={vote.account_address}>
                               &nbsp;
                               <Address value={vote.account_address} />
                             </Blockie>
                           </Table.Cell>
                           <Table.Cell>
+                            <span className="mobile-header">
+                              {isDistrictToken(poll.token)
+                                ? t('global.contributions')
+                                : t('poll_detail_page.amount')}
+                              :&nbsp;
+                            </span>
                             <Token
                               token={poll.token}
                               amount={vote.account_balance}
@@ -252,6 +266,10 @@ export default class PollDetailPage extends React.PureComponent<Props, State> {
                             />
                           </Table.Cell>
                           <Table.Cell>
+                            <span className="mobile-header">
+                              {t('poll_detail_page.vote')}
+                              :&nbsp;
+                            </span>
                             {getVoteOptionValue(poll.options, vote)}
                           </Table.Cell>
                         </Table.Row>


### PR DESCRIPTION
This adds headers to the votes on mobile

before:

<img width="391" alt="screen shot 2018-08-21 at 6 21 42 pm" src="https://user-images.githubusercontent.com/2781777/44432407-54132700-a578-11e8-800d-8110dd4e1025.png">

after:

<img width="448" alt="screen shot 2018-08-21 at 7 24 40 pm" src="https://user-images.githubusercontent.com/2781777/44432415-58d7db00-a578-11e8-8ebd-9094deb98ef8.png">
